### PR TITLE
Fix: Prevent race condition in navigation drawer

### DIFF
--- a/app/src/main/java/com/rafa/mi_bolsillo_app/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/rafa/mi_bolsillo_app/ui/dashboard/DashboardScreen.kt
@@ -74,8 +74,10 @@ fun DashboardScreen(
                     label = { Text(text = "Presupuestos") },
                     selected = false,
                     onClick = {
-                        navController.navigate(AppScreens.BudgetScreen.route)
-                        scope.launch { drawerState.close() }
+                        scope.launch {
+                            drawerState.close()
+                            navController.navigate(AppScreens.BudgetScreen.route)
+                        }
                     },
                     icon = { Icon(Icons.Filled.PieChart, contentDescription = "Presupuestos") },
                     modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
@@ -84,8 +86,10 @@ fun DashboardScreen(
                     label = { Text(text = "Categorías") },
                     selected = false,
                     onClick = {
-                        navController.navigate(AppScreens.CategoryManagementScreen.route)
-                        scope.launch { drawerState.close() }
+                        scope.launch {
+                            drawerState.close()
+                            navController.navigate(AppScreens.CategoryManagementScreen.route)
+                        }
                     },
                     icon = { Icon(Icons.Filled.List, contentDescription = "Categorías") },
                     modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
@@ -94,8 +98,10 @@ fun DashboardScreen(
                     label = { Text(text = "Plantillas Recurrentes") },
                     selected = false,
                     onClick = {
-                        navController.navigate(AppScreens.RecurringTransactionListScreen.route)
-                        scope.launch { drawerState.close() }
+                        scope.launch {
+                            drawerState.close()
+                            navController.navigate(AppScreens.RecurringTransactionListScreen.route)
+                        }
                     },
                     icon = { Icon(Icons.Filled.Autorenew, contentDescription = "Plantillas Recurrentes") },
                     modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
@@ -111,9 +117,11 @@ fun DashboardScreen(
                     label = { Text(text = "Ajustes") },
                     selected = false,
                     onClick = {
-                        navController.navigate(AppScreens.SettingsScreen.route)
-                        scope.launch { drawerState.close() }
-                              },
+                        scope.launch {
+                            drawerState.close()
+                            navController.navigate(AppScreens.SettingsScreen.route)
+                        }
+                    },
                     icon = { Icon(Icons.Filled.Settings, contentDescription = "Ajustes") },
                     modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
                 )


### PR DESCRIPTION
The previous implementation navigated to a new screen and then closed the navigation drawer. This could cause a race condition if the navigation was faster than the drawer closing animation, resulting in the UI getting stuck in a blank state.

This commit reverses the order of operations. The `onClick` handlers for the navigation drawer items now close the drawer first and then navigate to the selected screen. This ensures that the drawer is closed before the new screen is displayed, preventing the race condition.